### PR TITLE
Fix the :remove action for Windows

### DIFF
--- a/libraries/provider_skype_app_windows.rb
+++ b/libraries/provider_skype_app_windows.rb
@@ -32,6 +32,8 @@ class Chef
         PATH ||= ::File.expand_path('/Program Files (x86)/Skype')
         URL ||= 'http://www.skype.com/go/getskype-windows'
 
+        include ::Windows::Helper
+
         private
 
         #
@@ -52,9 +54,26 @@ class Chef
           end
         end
 
-        # TODO: def remove!
         #
-        # The Skype package name includes its version number.
+        # (see SkypeApp#remove!
+        #
+        def remove!
+          installed_skype_packages.each do |p|
+            windows_package p do
+              action :remove
+            end
+          end
+        end
+
+        #
+        # Iterate over all installed packages and return an array of any Skype
+        # package names.
+        #
+        # @return [Array] a list of installed Skype packages
+        #
+        def installed_skype_packages
+          installed_packages.keys.select { |k| k.match(/^Skype. [0-9]/) }
+        end
 
         #
         # Follow URL's redirect and return a final download URL. We need to

--- a/spec/libraries/provider_skype_app_windows_spec.rb
+++ b/spec/libraries/provider_skype_app_windows_spec.rb
@@ -40,6 +40,34 @@ describe Chef::Provider::SkypeApp::Windows do
     end
   end
 
+  describe '#remove!' do
+    before(:each) do
+      allow_any_instance_of(described_class)
+        .to receive(:installed_skype_packages).and_return(%w(pkg1 pkg2))
+    end
+
+    it 'removes all the installed Skype packages' do
+      p = provider
+      %w(pkg1 pkg2).each do |pkg|
+        expect(p).to receive(:windows_package).with(pkg).and_yield
+        expect(p).to receive(:action).with(:remove)
+      end
+      p.send(:remove!)
+    end
+  end
+
+  describe '#installed_skype_packages' do
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:installed_packages)
+        .and_return('Skype™ 1.2' => 'thing', 'Dropbox' => 'stuff')
+    end
+
+    it 'returns only the Skype package(s)' do
+      expected = ['Skype™ 1.2']
+      expect(provider.send(:installed_skype_packages)).to eq(expected)
+    end
+  end
+
   describe '#remote_path' do
     before(:each) do
       allow(Net::HTTP).to receive(:get_response).with(URI(described_class::URL))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'simplecov-console'
 require 'coveralls'
 require 'tmpdir'
 require 'fileutils'
+require_relative 'support/cookbooks/windows/libraries/windows_helper'
 
 RSpec.configure do |c|
   c.color = true


### PR DESCRIPTION
The package having a version number in its name means uninstalling is more difficult than it should be. :(
