### PR TITLE
support x64 ubuntu

### DIFF
--- a/libraries/provider_skype_app_ubuntu.rb
+++ b/libraries/provider_skype_app_ubuntu.rb
@@ -48,6 +48,12 @@ class Chef
             distribution node['lsb']['codename']
             action :add
           end
+          bash 'enable i386 packages' do
+            code <<-EOS
+              dpkg --add-architecture i386
+              apt-get update
+            EOS
+          end
           package 'skype' do
             action :install
           end


### PR DESCRIPTION
This codes are needed for 64bit ubuntu OS.
I checked this recipe in ubuntu 15.04 64bit and it worked correctly.
fyi: http://askubuntu.com/questions/215298/unable-to-install-skype-on-64bit-ubuntu
